### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/MMSMoA/a0035f39-0507-4ca7-81b4-e2d02bb44542/a984cf50-c34c-4d9f-b02a-9d588c4882a9/_apis/work/boardbadge/4e04f25b-3535-4264-b897-8f6a745702b7)](https://dev.azure.com/MMSMoA/a0035f39-0507-4ca7-81b4-e2d02bb44542/_boards/board/t/a984cf50-c34c-4d9f-b02a-9d588c4882a9/Microsoft.RequirementCategory)
 # Verify
 Issue tracker for verify.mmsmoa.com


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/MMSMoA/a0035f39-0507-4ca7-81b4-e2d02bb44542/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.